### PR TITLE
feat: add heading before post list

### DIFF
--- a/templates/authors/single.html
+++ b/templates/authors/single.html
@@ -53,6 +53,8 @@
           {% if author_page and author_page.content %}
           <div class="text-center">{{ author_page.content | safe }}</div>
           {% endif %}
+          <hr />
+          <h3>Posts de {{ title }}</h3>
           <div class="card-list">
             {% for page in term.pages %}
             <div class="card">


### PR DESCRIPTION
This PR adds a heading before the post list in the single author template.

Bellow is an example:
<img width="966" alt="author_template_heading_post" src="https://user-images.githubusercontent.com/39373170/195998227-200b337c-75c3-479a-bf83-2fc30dd4f7ea.png">

closes #6 